### PR TITLE
added configuration option selected_node so that vms can be created on s...

### DIFF
--- a/lib/vagrant-proxmox/action/select_node.rb
+++ b/lib/vagrant-proxmox/action/select_node.rb
@@ -12,7 +12,11 @@ module VagrantPlugins
 				end
 
 				def call env
-					env[:proxmox_selected_node] = env[:proxmox_nodes].sample
+					if env[:machine].provider_config.selected_node and env[:proxmox_nodes].include?(env[:machine].provider_config.selected_node)
+						env[:proxmox_selected_node] = env[:machine].provider_config.selected_node
+					else
+						env[:proxmox_selected_node] = env[:proxmox_nodes].sample
+					end
 					next_action env
 				end
 

--- a/lib/vagrant-proxmox/config.rb
+++ b/lib/vagrant-proxmox/config.rb
@@ -7,6 +7,11 @@ module VagrantPlugins
 			# @return [String]
 			attr_accessor :endpoint
 
+			# The Proxmox preferred cluster node
+			#
+			# @return [String]
+			attr_accessor :selected_node
+
 			# The Proxmox user name
 			#
 			# @return [String]
@@ -94,6 +99,7 @@ module VagrantPlugins
 
 			def initialize
 				@endpoint = UNSET_VALUE
+				@selected_node = UNSET_VALUE
 				@user_name = UNSET_VALUE
 				@password = UNSET_VALUE
 				@vm_type = UNSET_VALUE
@@ -116,6 +122,7 @@ module VagrantPlugins
 			# This is the hook that is called to finalize the object before it is put into use.
 			def finalize!
 				@endpoint = nil if @endpoint == UNSET_VALUE
+				@selected_node = nil if @endpoint == UNSET_VALUE
 				@user_name = nil if @user_name == UNSET_VALUE
 				@password = nil if @password == UNSET_VALUE
 				@vm_type = nil if @vm_type == UNSET_VALUE


### PR DESCRIPTION
...pecific cluster nodes

Hi,
i am running a 3-node-proxmox-cluster. I installed your plugin, played around and had a lot of fun. A very useful plugin!
But my virtual machines were created on random cluster nodes, so i wrote this patch in order to be able to force vm creation to happen on a specific proxmox node.

    config.vm.provider :proxmox do |proxmox|
        proxmox.endpoint = 'https://10.12.1.101:8006/api2/json'
        proxmox.selected_node = 'pxmxvm01'
        proxmox.user_name = 'vagrant'
        proxmox.password = 'fackrant'
        proxmox.vm_id_range = 900..910

Gerhard