### PR TITLE
improve configurability for qemu VMs: storage, nics, cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,18 @@ Vagrant.configure('2') do |config|
 		proxmox.user_name = 'vagrant'
 		proxmox.password = 'password'
 		proxmox.vm_id_range = 900..910
-        proxmox.vm_type = :qemu
+		proxmox.vm_type = :qemu
 		proxmox.vm_name_prefix = 'vagrant_'
-        proxmox.qemu_os = :l26
-        proxmox.qemu_disk_size = '30G'
-        proxmox.qemu_iso_file = '/home/user/system.iso'
-        proxmox.vm_id_range = 900..910
-        proxmox.vm_name_prefix = 'vagrant_test_'
-        proxmox.vm_memory = 512
+		proxmox.qemu_os = :l26
+		proxmox.qemu_disk_size = '30G'
+		proxmox.qemu_storage = 'local'
+		proxmox.qemu_iso_file = '/home/user/system.iso'
+		proxmox.vm_name_prefix = 'vagrant_test_'
+		proxmox.qemu_cores = 1
+		proxmox.qemu_sockets = 1
+		proxmox.qemu_nic_model = 'virtio'
+		proxmox.qemu_bridge = 'vmbr0'
+		proxmox.vm_memory = 512
 	end
 
 	config.vm.define :box, primary: true do |box|
@@ -120,6 +124,11 @@ Finally run `vagrant up --provider=proxmox` to create and start the new OpenVZ c
 * `qemu_iso` The qemu iso file to use for the virtual machine
 * `qemu_iso_file` The qemu iso file to upload and use for the virtual machine (can be specified instead of `qemu_iso`)
 * `qemu_disk_size` The qemu disk size to use for the virtual machine, e.g. '30G'
+* `qemu_storage` The storage pool to use, i.e. the value of the `storage` key of the hash returned by `pvesh get /nodes/{node}/storage`, e.g. 'raid', 'local', 'cephstore'
+* `qemu_cores` The number of cores per socket available to the VM
+* `qemu_sockets` The number of CPU sockets available to the VM
+* `qemu_nic_model` which model of network interface card to use, default 'e1000'
+* `qemu_bridge` connect automatically to this bridge, default 'vmbr0'
 * `selected_node` If specified, only this specific node is used to create machines 
 
 ## Build the plugin

--- a/lib/vagrant-proxmox/action/create_vm.rb
+++ b/lib/vagrant-proxmox/action/create_vm.rb
@@ -36,15 +36,15 @@ module VagrantPlugins
 
 				private
 				def create_params_qemu(config, env, vm_id)
-					network = 'e1000,bridge=vmbr0'
-					network = "e1000=#{get_machine_macaddress(env)},bridge=vmbr0" if get_machine_macaddress(env)
+					network = "#{config.qemu_nic_model},bridge=#{config.qemu_bridge}"
+					network = "#{config.qemu_nic_model}=#{get_machine_macaddress(env)},bridge=#{config.qemu_bridge}" if get_machine_macaddress(env)
 					{vmid: vm_id,
 					 name: env[:machine].config.vm.hostname || env[:machine].name.to_s,
 					 ostype: config.qemu_os,
 					 ide2: "#{config.qemu_iso},media=cdrom",
-					 sata0: "raid:#{config.qemu_disk_size},format=qcow2",
-					 sockets: 1,
-					 cores: 1,
+					 sata0: "#{config.qemu_storage}:#{config.qemu_disk_size},format=qcow2",
+					 sockets: config.qemu_sockets,
+					 cores: config.qemu_cores,
 					 memory: config.vm_memory,
 					 net0: network,
 					 description: "#{config.vm_name_prefix}#{env[:machine].name}"}

--- a/lib/vagrant-proxmox/config.rb
+++ b/lib/vagrant-proxmox/config.rb
@@ -82,6 +82,16 @@ module VagrantPlugins
 			# @return [Symbol]
 			attr_accessor :qemu_os
 
+			# The number of cores per socket
+			#
+			# @return [Integer]
+			attr_accessor :qemu_cores
+
+			# The number of CPU sockets
+			#
+			# @return [Integer]
+			attr_accessor :qemu_sockets
+
 			# The qemu iso file to use for the virtual machine
 			#
 			# @return [String]
@@ -96,6 +106,24 @@ module VagrantPlugins
 			#
 			# @return [String]
 			attr_accessor :qemu_disk_size
+
+			# The qemu storage to use for the virtual machine, e.g. 'local', 'raid', 'cephstore'
+			# defaults to 'raid' for backwards compatability
+			#
+			# @return [String]
+			attr_accessor :qemu_storage
+
+			# The qemu network interface card model, e.g. 'e1000', 'virtio'
+			# defaults to 'e1000' for backwards compatability
+			#
+			# @return [String]
+			attr_accessor :qemu_nic_model
+
+			# The qemu network bridge, e.g. 'vmbr0'
+			# defaults to 'vmbr0' for backwards compatability
+			#
+			# @return [String]
+			attr_accessor :qemu_bridge
 
 			def initialize
 				@endpoint = UNSET_VALUE
@@ -114,9 +142,14 @@ module VagrantPlugins
 				@ssh_status_check_interval = 5
 				@imgcopy_timeout = 120
 				@qemu_os = UNSET_VALUE
+				@qemu_cores = 1
+				@qemu_sockets = 1
 				@qemu_iso = UNSET_VALUE
 				@qemu_iso_file = UNSET_VALUE
 				@qemu_disk_size = UNSET_VALUE
+				@qemu_storage = 'raid'
+				@qemu_nic_model = 'e1000'
+				@qemu_bridge = 'vmbr0'
 			end
 
 			# This is the hook that is called to finalize the object before it is put into use.


### PR DESCRIPTION
* Provides configuration options for the number of sockets and cores-per-socket for qemu VMs
* Provides a configuration option for the storage 
* Provides a configuration option for the NIC model/driver and the (first) network bridge
* Uses the existing hard-coded values as defaults for backwards compatability
* fixes Issue #15 