### PR TITLE
add qemu_template, which allows to clone Qemu vms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ and provision Proxmox virtual machines.
 
 * Create/Destroy OpenVZ containers from specified templates
 * Start/Shutdown OpenVZ containers
+* Create/Destroy Qemu containers from specified templates or iso file
+* Start/Shutdown Qemu containers
 * SSH into virtual machine
 * Provision the virtual machine
 * Synced folder support via rsync
@@ -17,6 +19,7 @@ and provision Proxmox virtual machines.
 * For OpenVZ containers you need a Vagrant compatible OpenVZ template
 * For OpenVZ containers only routed network mode is currently supported
 * For KVM machines the ISO file needs to be a Vagrant compatible live system or automatic installation
+* For KVM machines the Qemu template has to be on the selected_node
 
 ## Requirements
 
@@ -125,6 +128,8 @@ Finally run `vagrant up --provider=proxmox` to create and start the new OpenVZ c
 * `qemu_iso` The qemu iso file to use for the virtual machine
 * `qemu_iso_file` The qemu iso file to upload and use for the virtual machine (can be specified instead of `qemu_iso`)
 * `replace_qemu_iso_file` Set to true if the iso file should be replaced on the server (default: false)
+* `replace_template` Set to true if the iso file should be replaced on the server (default: false)
+* `qemu_template` The name of a qemu template which is used to create a clone (can be specified instead of `qemu_iso[_file]`)
 * `qemu_disk_size` The qemu disk size to use for the virtual machine, e.g. '30G'
 * `qemu_storage` The storage pool to use, i.e. the value of the `storage` key of the hash returned by `pvesh get /nodes/{node}/storage`, e.g. 'raid', 'local', 'cephstore'
 * `qemu_cores` The number of cores per socket available to the VM

--- a/lib/vagrant-proxmox/action.rb
+++ b/lib/vagrant-proxmox/action.rb
@@ -47,15 +47,32 @@ module VagrantPlugins
 									end
 								end
 							elsif env1[:machine].provider_config.vm_type == :qemu
-								b1.use Call, UploadIsoFile do |env2, b2|
-									if env2[:result] == :ok
-										b2.use CreateVm
-										b2.use StartVm
-										b2.use SyncFolders
-									elsif env2[:result] == :file_not_found
-										b2.use MessageFileNotFound
-									elsif env2[:result] == :server_upload_error
-										b2.use MessageUploadServerError
+								if env1[:machine].provider_config.qemu_iso
+									b1.use Call, UploadIsoFile do |env2, b2|
+										if env2[:result] == :ok
+											b2.use CreateVm
+											b2.use StartVm
+											b2.use SyncFolders
+										elsif env2[:result] == :file_not_found
+											b2.use MessageFileNotFound
+										elsif env2[:result] == :server_upload_error
+											b2.use MessageUploadServerError
+										end
+									end
+								else
+									b1.use CloneVm
+									b1.use Call, IsCreated do |env2, b2|
+										if env2[:result]
+											b2.use CloneVm
+											b2.use AdjustForwardedPortParams
+											b2.use ConfigClone
+											b2.use StartVm
+											b2.use SyncFolders
+										elsif env2[:result] == :file_not_found
+											b2.use MessageFileNotFound
+										elsif env2[:result] == :server_upload_error
+											b2.use MessageUploadServerError
+										end
 									end
 								end
 							end
@@ -134,6 +151,9 @@ module VagrantPlugins
 			Vagrant::Action::Builder.new.tap do |b|
 				b.use ConfigValidate
 				b.use ConnectProxmox
+				b.use GetNodeList
+				b.use SelectNode
+				b.use AdjustForwardedPortParams
 				b.use ReadSSHInfo
 			end
 		end
@@ -191,6 +211,9 @@ module VagrantPlugins
 		autoload :MessageFileNotFound, action_root.join('message_file_not_found')
 		autoload :MessageUploadServerError, action_root.join('message_upload_server_error')
 		autoload :CreateVm, action_root.join('create_vm')
+		autoload :CloneVm, action_root.join('clone_vm')
+		autoload :AdjustForwardedPortParams, action_root.join('adjust_forwarded_port_params')
+		autoload :ConfigClone, action_root.join('config_clone')
 		autoload :StartVm, action_root.join('start_vm')
 		autoload :StopVm, action_root.join('stop_vm')
 		autoload :ShutdownVm, action_root.join('shutdown_vm')

--- a/lib/vagrant-proxmox/action.rb
+++ b/lib/vagrant-proxmox/action.rb
@@ -63,7 +63,6 @@ module VagrantPlugins
 									b1.use CloneVm
 									b1.use Call, IsCreated do |env2, b2|
 										if env2[:result]
-											b2.use CloneVm
 											b2.use AdjustForwardedPortParams
 											b2.use ConfigClone
 											b2.use StartVm

--- a/lib/vagrant-proxmox/action/adjust_forwarded_port_params.rb
+++ b/lib/vagrant-proxmox/action/adjust_forwarded_port_params.rb
@@ -1,0 +1,42 @@
+module VagrantPlugins
+	module Proxmox
+		module Action
+
+			# This action creates a new virtual machine on the Proxmox server and
+			# stores its node and vm_id env[:machine].id
+			class AdjustForwardedPortParams < ProxmoxAction
+
+				def initialize app, env
+					@app = app
+					@logger = Log4r::Logger.new 'vagrant_proxmox::action::adjust_forwarded_port_params'
+				end
+
+				def call env
+					env[:ui].info I18n.t('vagrant_proxmox.adjust_forwarded_port_params')
+					config = env[:machine].provider_config
+					node = env[:proxmox_selected_node]
+					vm_id = nil
+
+					begin
+						vm_id = env[:machine].id.split("/").last
+						node_ip = env[:proxmox_connection].get_node_ip(node, 'vmbr0')
+						env[:machine].config.vm.networks.each do |type, options|
+							next if type != :forwarded_port
+							if options[:id] == "ssh"
+								# Provisioning and vagrant ssh will use this
+								# high port of the selected proxmox node
+								options[:auto_correct] = false
+								options[:host_ip] = node_ip
+								options[:host] = sprintf("22%03d", vm_id.to_i).to_i
+								env[:machine].config.ssh.host = node_ip
+								env[:machine].config.ssh.port = sprintf("22%03d", vm_id.to_i).to_s
+								break
+							end
+						end
+					end
+					next_action env
+				end
+			end
+		end
+	end
+end

--- a/lib/vagrant-proxmox/action/clone_vm.rb
+++ b/lib/vagrant-proxmox/action/clone_vm.rb
@@ -1,0 +1,55 @@
+module VagrantPlugins
+	module Proxmox
+		module Action
+
+			# This action clones from a qemu template on the Proxmox server and
+			# stores its node and vm_id env[:machine].id
+			class CloneVm < ProxmoxAction
+
+				def initialize app, env
+					@app = app
+					@logger = Log4r::Logger.new 'vagrant_proxmox::action::clone_vm'
+				end
+
+				def call env
+					env[:ui].info I18n.t('vagrant_proxmox.cloning_vm')
+					config = env[:machine].provider_config
+
+					node = env[:proxmox_selected_node]
+					vm_id = nil
+					template_vm_id = nil
+
+					begin
+						template_vm_id = connection(env).get_qemu_template_id(config.qemu_template)
+					rescue StandardError => e
+						raise VagrantPlugins::Proxmox::Errors::VMCloneError, proxmox_exit_status: e.message
+					end
+	
+					begin
+						vm_id = connection(env).get_free_vm_id
+						params = create_params_qemu(config, env, vm_id, template_vm_id)
+						exit_status = connection(env).clone_vm node: node, vm_type: config.vm_type, params: params
+						exit_status == 'OK' ? exit_status : raise(VagrantPlugins::Proxmox::Errors::ProxmoxTaskFailed, proxmox_exit_status: exit_status)
+					rescue StandardError => e
+						raise VagrantPlugins::Proxmox::Errors::VMCloneError, proxmox_exit_status: e.message
+					end
+
+					env[:machine].id = "#{node}/#{vm_id}"
+
+					env[:ui].info I18n.t('vagrant_proxmox.done')
+					next_action env
+				end
+
+				private
+				def create_params_qemu(config, env, vm_id, template_vm_id)
+					# without network, which will added in ConfigClonedVm
+					{vmid: template_vm_id,
+					 newid: vm_id,
+					 name: env[:machine].config.vm.hostname || env[:machine].name.to_s,
+					 description: "#{config.vm_name_prefix}#{env[:machine].name}"}
+				end
+
+			end
+		end
+	end
+end

--- a/lib/vagrant-proxmox/action/config_clone.rb
+++ b/lib/vagrant-proxmox/action/config_clone.rb
@@ -1,0 +1,98 @@
+module VagrantPlugins
+	module Proxmox
+		module Action
+
+			# This action modifies the configuration of a cloned vm
+			# Basically it creates a user network interface with hostfwd for the provisioning
+			# and an interface for every public or private interface defined in the Vagrantfile
+			class ConfigClone < ProxmoxAction
+
+				def initialize app, env
+					@app = app
+					@logger = Log4r::Logger.new 'vagrant_proxmox::action::config_clone'
+					@node_ip = nil
+					@guest_port = nil
+				end
+
+				def call env
+					env[:ui].info I18n.t('vagrant_proxmox.configuring_vm')
+					config = env[:machine].provider_config
+					node = env[:proxmox_selected_node]
+					vm_id = nil
+
+					begin
+						vm_id = env[:machine].id.split("/").last
+						@node_ip = connection(env).get_node_ip(node, 'vmbr0') if config.vm_type == :qemu
+						@guest_port = sprintf("22%03d", vm_id.to_i).to_s
+					rescue StandardError => e
+						raise VagrantPlugins::Proxmox::Errors::VMConfigError, proxmox_exit_status: e.message
+					end
+
+					begin
+						template_config = connection(env).get_vm_config node: node, vm_id: vm_id, vm_type: config.vm_type
+						params = create_params_qemu(config, env, vm_id, template_config)
+						exit_status = connection(env).config_clone node: node, vm_type: config.vm_type, params: params
+						exit_status == 'OK' ? exit_status : raise(VagrantPlugins::Proxmox::Errors::ProxmoxTaskFailed, proxmox_exit_status: exit_status)
+					rescue StandardError => e
+						raise VagrantPlugins::Proxmox::Errors::VMConfigError, proxmox_exit_status: e.message
+					end
+
+					env[:ui].info I18n.t('vagrant_proxmox.done')
+					next_action env
+				end
+
+				private
+				def create_params_qemu(provider_config, env, vm_id, template_config)
+					vm_config = env[:machine].config.vm
+					params = {
+						vmid: vm_id,
+						description: "#{provider_config.vm_name_prefix}#{env[:machine].name}",
+					}
+					# delete existing network interfaces from template
+					to_delete = template_config.keys.select{|key| key.to_s.match(/^net/) }
+					params[:delete] = to_delete.join(",") if not to_delete.empty?
+					# net0 is the provisioning network, derived from forwarded_port
+					net_num = 0
+					hostname = vm_config.hostname || env[:machine].name
+					netdev0 = [
+						"type=user",
+						"id=net0",
+						"hostname=#{hostname}",
+						"hostfwd=tcp:#{@node_ip}:#{@guest_port}-:22",	# selected_node's primary ip and port (22000 + vm_id)
+					]
+					device0 = [
+						"#{provider_config.qemu_nic_model}",
+						"netdev=net0",
+						"bus=pci.0",
+						"addr=0x12",					# starting point for network interfaces
+						"id=net0",
+						"bootindex=299"
+					]
+					params[:args] = "-netdev " + netdev0.join(",") + " -device " + device0.join(",")
+					# now add a network device for every public_network or private_network
+					# ip addresses are ignored here, as we can't configure anything inside the qemu vm.
+					# at least we can set the predefined mac address and a bridge
+					net_num += 1
+					vm_config.networks.each do |type, options|
+						next if not type.match(/^p.*_network$/)
+						nic = provider_config.qemu_nic_model
+						nic += "=#{options[:macaddress]}" if options[:macaddress]
+						nic += ",bridge=#{options[:bridge]}" if options[:bridge]
+						net = 'net' + net_num.to_s
+						params[net] = nic
+						net_num += 1
+					end
+
+					# some more individual settings
+					params[:ide2] = "#{provider_config.qemu_iso},media=cdrom" if provider_config.qemu_iso
+					params[:sockets] = "#{provider_config.qemu_sockets}".to_i if provider_config.qemu_sockets
+					params[:cores] = "#{provider_config.qemu_cores}".to_i if provider_config.qemu_cores
+					params[:balloon] = "#{provider_config.vm_memory}".to_i if provider_config.vm_memory and provider_config.vm_memory < template_config[:balloon]
+					params[:memory] = "#{provider_config.vm_memory}".to_i if provider_config.vm_memory
+					params
+				end
+
+			end
+		end
+	end
+end

--- a/lib/vagrant-proxmox/action/proxmox_action.rb
+++ b/lib/vagrant-proxmox/action/proxmox_action.rb
@@ -11,7 +11,12 @@ module VagrantPlugins
 
 				protected
 				def get_machine_ip_address env
-					env[:machine].config.vm.networks.select { |type, _| type == :public_network }.first[1][:ip] rescue nil
+					config = env[:machine].provider_config
+					if config.vm_type == :qemu
+						env[:machine].config.vm.networks.select { |type, _| type == :forwarded_port }.first[1][:host_ip] rescue nil
+					else
+						env[:machine].config.vm.networks.select { |type, _| type == :public_network }.first[1][:ip] rescue nil
+					end
 				end
 
 				protected

--- a/lib/vagrant-proxmox/action/read_ssh_info.rb
+++ b/lib/vagrant-proxmox/action/read_ssh_info.rb
@@ -7,12 +7,14 @@ module VagrantPlugins
 
 				def initialize app, env
 					@app = app
+					@logger = Log4r::Logger.new 'vagrant_proxmox::action::read_ssh_info'
 				end
 
 				def call env
 					env[:machine_ssh_info] = get_machine_ip_address(env).try do |ip_address|
 						{host: ip_address, port: env[:machine].config.ssh.guest_port}
 					end
+					env[:machine_ssh_info]
 					next_action env
 				end
 

--- a/lib/vagrant-proxmox/config.rb
+++ b/lib/vagrant-proxmox/config.rb
@@ -97,6 +97,11 @@ module VagrantPlugins
 			# @return [Integer]
 			attr_accessor :qemu_sockets
 
+			# The qemu template to clone for the virtual machine
+			#
+			# @return [String]
+			attr_accessor :qemu_template
+
 			# The qemu iso file to use for the virtual machine
 			#
 			# @return [String]
@@ -155,6 +160,7 @@ module VagrantPlugins
 				@qemu_os = UNSET_VALUE
 				@qemu_cores = 1
 				@qemu_sockets = 1
+				@qemu_template = UNSET_VALUE
 				@qemu_iso = UNSET_VALUE
 				@qemu_iso_file = UNSET_VALUE
 				@replace_qemu_iso_file = false
@@ -174,6 +180,7 @@ module VagrantPlugins
 				@openvz_template_file = nil if @openvz_template_file == UNSET_VALUE
 				@openvz_os_template = "local:vztmpl/#{File.basename @openvz_template_file}" if @openvz_template_file
 				@openvz_os_template = nil if @openvz_os_template == UNSET_VALUE
+				@qemu_template = nil if @qemu_os == UNSET_VALUE
 				@qemu_os = nil if @qemu_os == UNSET_VALUE
 				@qemu_iso_file = nil if @qemu_iso_file == UNSET_VALUE
 				@qemu_iso = "local:iso/#{File.basename @qemu_iso_file}" if @qemu_iso_file
@@ -192,9 +199,12 @@ module VagrantPlugins
 					errors << I18n.t('vagrant_proxmox.errors.no_openvz_os_template_or_openvz_template_file_specified_for_type_openvz') unless @openvz_os_template || @openvz_template_file
 				end
 				if @vm_type == :qemu
-					errors << I18n.t('vagrant_proxmox.errors.no_qemu_os_specified_for_vm_type_qemu') unless @qemu_os
-					errors << I18n.t('vagrant_proxmox.errors.no_qemu_iso_or_qemu_iso_file_specified_for_vm_type_qemu') unless @qemu_iso || @qemu_iso_file
-					errors << I18n.t('vagrant_proxmox.errors.no_qemu_disk_size_specified_for_vm_type_qemu') unless @qemu_disk_size
+					if @qemu_template
+					else
+						errors << I18n.t('vagrant_proxmox.errors.no_qemu_os_specified_for_vm_type_qemu') unless @qemu_os
+						errors << I18n.t('vagrant_proxmox.errors.no_qemu_iso_or_qemu_iso_file_specified_for_vm_type_qemu') unless @qemu_iso || @qemu_iso_file
+						errors << I18n.t('vagrant_proxmox.errors.no_qemu_disk_size_specified_for_vm_type_qemu') unless @qemu_disk_size
+					end
 				end
 				{'Proxmox Provider' => errors}
 			end

--- a/lib/vagrant-proxmox/errors.rb
+++ b/lib/vagrant-proxmox/errors.rb
@@ -30,6 +30,18 @@ module VagrantPlugins
 				error_key :vm_create_error
 			end
 
+			class VMCloneError < VagrantProxmoxError
+				error_key :vm_clone_error
+			end
+
+			class NoTemplateAvailable < VagrantProxmoxError
+				error_key :no_template_available
+			end
+
+			class VMConfigError < VagrantProxmoxError
+				error_key :vm_configure_error
+			end
+
 			class VMDestroyError < VagrantProxmoxError
 				error_key :vm_destroy_error
 			end


### PR DESCRIPTION
You can vagrant up such a box:
```
  config.vm.provider :proxmox do |proxmox|
    proxmox.endpoint = 'https://10.2.15.15:8006/api2/json'
    proxmox.selected_node = 'vm02'
    ...
    proxmox.vm_id_range = 900..999
    proxmox.vm_name_prefix = 'vagrant_'
    proxmox.qemu_template = 'debian-8.1-amd64'
    #proxmox.qemu_iso = "debian.iso"
    proxmox.qemu_disk_size = 10
    proxmox.qemu_storage = "local"
    proxmox.qemu_os = 'l26'
    proxmox.qemu_bridge = 'vmbr0'
    proxmox.vm_type = :qemu
    proxmox.vm_memory = 256
    proxmox.ssh_timeout = 30
  end
  config.vm.boot_timeout = 180
  config.vm.provision :shell, :path => "provision/common.sh"

  config.vm.define :box, primary: true do |box|
    box.vm.box = 'dummy'
    box.vm.network :public_network, macaddress: '00:25:80:a7:13:ca'
    box.vm.network :private_network, macaddress: '00:25:80:a7:13:cb'
    box.vm.network :public_network, macaddress: '00:25:80:a7:13:cc', ip: '10.8.12.2', bridge: 'vmbr1'
  end
```
The qemu template Debian-8.1 has to be located on selected_node vm02. 
A linked clone is created (which is really fast)
Internally a user-network with hostfw is created, ip is the ip of selected_node vm02, port is 22000 + the vm-id of the clone. This  network is used by "vagrant ssh" and for provisioning.
Three other network devices are created. They are given the mac addresses specified in the Vagrantfile. The third nic sits on bridge vmbr1. Only the ip: is ignored.
 
