### PR TITLE
create_params_lxc: storage parameter doesn't support size

### DIFF
--- a/lib/vagrant-proxmox/action/create_vm.rb
+++ b/lib/vagrant-proxmox/action/create_vm.rb
@@ -70,7 +70,7 @@ module VagrantPlugins
 					 ostemplate: config.openvz_os_template,
 					 hostname: env[:machine].config.vm.hostname || env[:machine].name.to_s,
 					 password: 'vagrant',
-					 storage: "#{config.vm_storage}:#{config.vm_disk_size}",
+					 rootfs: "#{config.vm_storage}:#{config.vm_disk_size}",
 					 memory: config.vm_memory,
 					 description: "#{config.vm_name_prefix}#{env[:machine].name}"}
 					.tap do |params|


### PR DESCRIPTION
The storage parameter is for the storage only, nothing more.
Use the rootfs parameter to correctly sent the the disk size
and the storage to the PVE API2.

Addresses:
https://github.com/telcat/vagrant-proxmox/pull/26#issuecomment-208353670
